### PR TITLE
Support more source types

### DIFF
--- a/src/graphql_builder/parser.clj
+++ b/src/graphql_builder/parser.clj
@@ -2,11 +2,19 @@
   (:require [graphql-clj.parser :as parser]
             [clojure.walk :as walk]
             [graphql-clj.box :as box]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.java.io :as io]))
 
 (defn parse [statement]
   (walk/prewalk box/box->val (parser/parse statement)))
 
+(defn read-file [file]
+  (slurp
+   (condp instance? file
+     java.io.File file
+     java.net.URL file
+     (or (io/resource file) file))))
+
 (defmacro defgraphql [name & files]
-  (let [parsed (parse (str/join "\n" (map slurp files)))]
-    `(def ~name ~parsed)))
+  `(let [parsed# (parse (str/join "\n" (map read-file [~@files])))]
+     (def ~name parsed#)))


### PR DESCRIPTION
Current `defgraphql` seems to support only string expression of file paths. This PR adds support for more source types.

```clojure
(require '[clojure.java.io :as io])

;; java.io.File
(defgraphql graphql-queries (io/file "path/to/file.graphql"))

;; java.net.URL
(defgraphql graphql-queries (io/resource "resource_file.graphql"))

;; find from resource path
(defgraphql graphql-queries "resource_file.graphql")
```

This behavior is similar to `def-db-fns` of HugSQL.