### PR TITLE
Added support for recursively parsing argument values

### DIFF
--- a/src/graphql_builder/generators/shared.cljc
+++ b/src/graphql_builder/generators/shared.cljc
@@ -40,6 +40,9 @@
     (and (map? v) (get v :values))
     (generate-arg-vector (get v :values))
 
+    (and (map? v) (get v :variable-name))
+    (str "$" (get v :variable-name))
+
     (vector? v)
     (generate-arg-list v)
 

--- a/test/graphql_builder/core_test.clj
+++ b/test/graphql_builder/core_test.clj
@@ -811,3 +811,19 @@ query Foo {
         query-fn (get-in query-map [:query :foo])]
     (is (= (str/trim object-argument-parsing-source)
            (get-in (query-fn) [:graphql :query])))))
+
+(def object-argument-parsing-source-2
+  "query Foo($id: String, $patch: String) {
+  productList(filter: { id: $id, patch: $patch }) {
+    nodes {
+      productNumber
+    }
+  }
+}
+")
+
+(deftest object-argument-parsing-2-test
+  (let [query-map (core/query-map (parse object-argument-parsing-source-2))
+        query-fn (get-in query-map [:query :foo])]
+    (is (= (str/trim object-argument-parsing-source-2)
+           (get-in (query-fn) [:graphql :query])))))

--- a/test/graphql_builder/core_test.clj
+++ b/test/graphql_builder/core_test.clj
@@ -789,8 +789,25 @@ query Foo {
 }
 ")
 
-(deftest enums-arg-test
+(deftest enums-arg-2-test
   (let [query-map (core/query-map (parse argument-false-source) {})
         query-fn (get-in query-map [:query :foo])]
     (is (= (str/trim argument-false-source)
+           (get-in (query-fn) [:graphql :query])))))
+
+
+(def object-argument-parsing-source
+  "query Foo($item: String) {
+  productList(filter: { value: \"foo\", contains: [\"A\", \"B\"], using: {item: $item} }) {
+    nodes {
+      productNumber
+    }
+  }
+}
+")
+
+(deftest object-argument-parsing-test
+  (let [query-map (core/query-map (parse object-argument-parsing-source))
+        query-fn (get-in query-map [:query :foo])]
+    (is (= (str/trim object-argument-parsing-source)
            (get-in (query-fn) [:graphql :query])))))


### PR DESCRIPTION
Hi!

Thanks for this awesome library. We have started using it in our project and noticed that the object value parsing does not handle situtations that we currently have, e.g.

```graphql
query Search($productNumber: String!) {
    products(filter: {productNumber: {equalTo: $productNumber}}) {
        nodes {
            id
            productNumber
            names
        }
    }
}
```

This PR adds a recursive handling for any parameters in the arguments. Seems to be working for our use case – let me know if there are any corners that I have not noticed. The tests seem to be still passing.