### PR TITLE
Fix elision of literal null values when generating operations from parsed AST

### DIFF
--- a/src/graphql_builder/generators/shared.cljc
+++ b/src/graphql_builder/generators/shared.cljc
@@ -4,9 +4,10 @@
 
 ;; ToDo - check enum type vs string quoting, write tests for mixed enums in list node type
 (defn quote-arg [v]
-  (if (string? v)
-    (str "\"" v "\"")
-    v))
+  (cond
+    (string? v) (str "\"" v "\"")
+    (nil? v) "null"
+    :else v))
 
 (defn add-var-prefix [prefix name]
   (if prefix
@@ -21,6 +22,7 @@
     :string (str "\"" value "\"")
     :object (generate-arg-list value prefix)
     :list (generate-arg-vector (:values value) prefix)
+    :null "null"
     value))
 
 (defn generate-arg-vector [args prefix]

--- a/test/graphql_builder/core_test.clj
+++ b/test/graphql_builder/core_test.clj
@@ -974,3 +974,27 @@ mutation ComposedMutation($AddStarship1__name: String!, $AddStarship2__name: Str
   (let [query-map (core/query-map (parse argument-defaults))
         query-fn (get-in query-map [:query :post-collection-query])]
     (is (= (str/trim argument-defaults) (get-in (query-fn) [:graphql :query])))))
+
+(def argument-object-value-literal-null-query
+  "query literalNull {
+  events(where: { deletedAt: null }) {
+    id
+  }
+}")
+
+(deftest argument-object-value-literal-null-test
+  (let [query-map (core/query-map (parse argument-object-value-literal-null-query))
+        query-fn (get-in query-map [:query :literal-null])]
+    (is (= (str/trim argument-object-value-literal-null-query) (get-in (query-fn) [:graphql :query])))))
+
+(def field-value-literal-null-query
+  "query literalNull {
+  events(where: { or: [{deletedAt: null}, {deletedAt_gt: \"2023-11-28T00:00:00Z\"}] }) {
+    id
+  }
+}")
+
+(deftest field-value-literal-null-test
+  (let [query-map (core/query-map (parse field-value-literal-null-query))
+        query-fn (get-in query-map [:query :literal-null])]
+    (is (= (str/trim field-value-literal-null-query) (get-in (query-fn) [:graphql :query])))))


### PR DESCRIPTION
Given graphql that contains literal null values, like the following

```graphql
query(
  $date: DateTime
) {
  events(
    where: {
      occurredAt: $date
      deletedAt: null
    }
  ) {
    id
    eventType
  }
}
```

The alumbra parser correctly parses these null values, but when the query string is regenerated the null is gone, leading to invalid graphql. The fix in this commit addresses this in two different locations. I encountered each of these functions needing to handle different representations of null values, based on the AST that was being generated. I am not sure if there are also other representations in the AST of literal nulls that need to be identified and handled.